### PR TITLE
Added s3service.s3-endpoint property to alfresco-global.properties

### DIFF
--- a/scripts/share-51.json
+++ b/scripts/share-51.json
@@ -46,6 +46,7 @@
             "s3.bucketLocation" : "@@AWS_REGION@@",
             "s3service.https-only" : true,
             "s3service.s3-endpoint-https-port" : "443",
+            "s3service.s3-endpoint" : "@@AWS_S3ENDPOINT@@",
             "alfresco_user_store.adminpassword" : "@@ALFRESCO_PASSWORD@@",
             "alfresco.cluster.enabled" : true
         },

--- a/scripts/solr-51.json
+++ b/scripts/solr-51.json
@@ -31,6 +31,7 @@
             "s3.bucketLocation" : "@@AWS_REGION@@",
             "s3service.https-only" : true,
             "s3service.s3-endpoint-https-port" : "443",
+            "s3service.s3-endpoint" : "@@AWS_S3ENDPOINT@@",
             "solr.port" : "8090",
             "alfresco_user_store.adminpassword" : "@@ALFRESCO_PASSWORD@@"
         },

--- a/templates/alfresco-one.template
+++ b/templates/alfresco-one.template
@@ -460,6 +460,50 @@
                 "Partition": "aws",
                 "QuickStartS3URL": "https://s3.amazonaws.com"
             }
+        },
+        "S3EndPoints": {
+            "us-east-1": {
+              "endpoint": "s3-external-1.amazonaws.com"
+            },
+            "us-east-2": {
+              "endpoint": "s3-us-east-2.amazonaws.com"
+            },
+            "us-west-1": {
+              "endpoint": "s3-us-west-1.amazonaws.com"
+            },
+            "us-west-2": {
+              "endpoint": "s3-us-west-2.amazonaws.com"
+            },
+            "ca-central-1": {
+              "endpoint": "s3-ca-central-1.amazonaws.com"
+            },
+            "ap-south-1": {
+              "endpoint": "s3-ap-south-1.amazonaws.com"
+            },
+            "ap-northeast-2": {
+              "endpoint": "s3-ap-northeast-2.amazonaws.com"
+            },
+            "ap-southeast-1": {
+              "endpoint": "s3-ap-southeast-1.amazonaws.com"
+            },
+            "ap-southeast-2": {
+              "endpoint": "s3-ap-southeast-2.amazonaws.com"
+            },
+            "ap-northeast-1": {
+              "endpoint": "s3-ap-northeast-1.amazonaws.com"
+            },
+            "eu-central-1": {
+              "endpoint": "s3-eu-central-1.amazonaws.com"
+            },
+            "eu-west-1": {
+              "endpoint": "s3-eu-west-1.amazonaws.com"
+            },
+            "eu-west-2": {
+              "endpoint": "s3-eu-west-2.amazonaws.com"
+            },
+            "sa-east-1": {
+              "endpoint": "s3-sa-east-1.amazonaws.com"
+            }
         }
     },
     "Conditions": {
@@ -983,6 +1027,17 @@
                                                 "Ref": "AWS::Region"
                                             },
                                             "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@AWS_S3ENDPOINT@@/",
+                                            {
+                                                "Fn::FindInMap": [
+                                                    "S3EndPoints",
+                                                    {
+                                                        "Ref": "AWS::Region"
+                                                    },
+                                                    "endpoint"
+                                                ]
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
                                             "ALFPASS=$(printf %s ",
                                             {
                                                 "Ref": "AlfrescoPassword"
@@ -1358,6 +1413,17 @@
                                             "sed -i 's/@@AWS_REGION@@/",
                                             {
                                                 "Ref": "AWS::Region"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@AWS_S3ENDPOINT@@/",
+                                            {
+                                                "Fn::FindInMap": [
+                                                    "S3EndPoints",
+                                                    {
+                                                        "Ref": "AWS::Region"
+                                                    },
+                                                    "endpoint"
+                                                ]
                                             },
                                             "/g' /etc/chef/chef-client.json\n",
                                             "ALFPASS=$(printf %s ",


### PR DESCRIPTION
With this property we prevent an eventual error restarting tomcat after first deployment en any region other than N. Virginia. 