### PR TITLE
New version for Alfresco Content Services 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Alfresco One on the AWS Cloud
+# Alfresco Content Services on the AWS Cloud
 ## Quick Start Reference Deployment
 
-This new Quick Start automatically deploys an Alfresco One cluster on the AWS Cloud. The Quick Start was created by AWS in partnership with Alfresco Software, to integrate solutions and services from both companies.
-Alfresco One is an Enterprise Content Management (ECM) system that is used for document and case management, project collaboration, web content publishing, and compliant records management. The flexible compute, storage, and database services that AWS offers make it an ideal platform for Alfresco One. This Quick Start presents an enterprise-grade Alfresco One configuration that you can adapt to virtually any scenario, and scale up, down, or out, depending on your use case.
+This new Quick Start automatically deploys an Alfresco Content Services cluster on the AWS Cloud. The Quick Start was created by AWS in partnership with Alfresco Software, to integrate solutions and services from both companies.
+Alfresco Content Services is an Enterprise Content Management (ECM) system that is used for document and case management, project collaboration, web content publishing, and compliant records management. The flexible compute, storage, and database services that AWS offers make it an ideal platform for Alfresco Content Services. This Quick Start presents an enterprise-grade Alfresco Content Services configuration that you can adapt to virtually any scenario, and scale up, down, or out, depending on your use case.
 
-![Quick Start Alfresco One Design Architecture](https://d3ulk6ur3a3ha.cloudfront.net/partner-network/QuickStart/datasheets/alfresco-architecture-diagram.png)
+![Quick Start Alfresco Content Services Design Architecture](https://d3ulk6ur3a3ha.cloudfront.net/partner-network/QuickStart/datasheets/alfresco-architecture-diagram.png)
 
 The Quick Start architecture includes the following components:
-* Highly available Alfresco One servers and Index servers deployed across two Availability Zones within your selected region. The servers take advantage of Auto Scaling and Elastic Load Balancing, with CPU-based thresholds that you can customize.
+* Highly available Alfresco Content Services servers and Index servers deployed across two Availability Zones within your selected region. The servers take advantage of Auto Scaling and Elastic Load Balancing, with CPU-based thresholds that you can customize.
 * Amazon Simple Storage Service (Amazon S3) for shared file storage.
-* Amazon Relational Database System (Amazon RDS) for MySQL with Multi-AZ enabled for the shared database. If you expect your database to exceed 6 TB, you can also switch to Amazon Aurora.
+* Amazon Relational Database System (Amazon RDS) Aurora in cluster (MySQL with Multi-AZ enabled if Frankfurt region) for the shared database.
 
-The Alfresco One deployment is automated by nested AWS CloudFormation templates. The templates call custom Chef cookbooks to automate installation and configuration tasks for Alfresco One. The Quick Start gives you a option to either build a new AWS environment for Alfresco One or use your existing AWS environment.
+The Alfresco Content Services deployment is automated by nested AWS CloudFormation templates. The templates call custom Chef cookbooks to automate installation and configuration tasks for Alfresco Content Services. The Quick Start gives you a option to either build a new AWS environment for Alfresco Content Services or use your existing AWS environment.
 
 
 Deployment Guide: https://s3.amazonaws.com/quickstart-reference/alfresco/one/latest/doc/alfresco-one-on-the-aws-cloud.pdf

--- a/scripts/run-index-fk.sh
+++ b/scripts/run-index-fk.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+cd /etc/chef; chef-client -z -j chef-client.json
+systemctl stop nginx
+systemctl disable nginx
+yum remove -y nginx
+systemctl disable haproxy
+systemctl stop haproxy
+yum remove -y haproxy
+rm -fr /etc/haproxy/haproxy.cfg
+rm -fr /var/log/haproxy
+systemctl stop mysql-default
+systemctl disable mysql-default
+systemctl stop tomcat-share
+systemctl disable tomcat-share
+yum remove -y mysql-server
+rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service
+rm -fr /etc/tomcat-share /var/lib/tomcat-share /usr/share/tomcat-share /var/log/tomcat-share /var/cache/tomcat-share /etc/sysconfig/tomcat-share /usr/lib/systemd/system/tomcat-share.service
+rm -fr /etc/chef/chef-client.json
+rm -fr /etc/chef/nodes/*.json
+chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties
+rm -fr /etc/chef/replaceValues.sh
+rm -fr /etc/chef/run.sh

--- a/scripts/run-index.sh
+++ b/scripts/run-index.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+cd /etc/chef; chef-client -z -j chef-client.json
+systemctl stop nginx
+systemctl disable nginx
+yum remove -y nginx
+systemctl disable haproxy
+systemctl stop haproxy
+yum remove -y haproxy
+rm -fr /etc/haproxy/haproxy.cfg
+rm -fr /var/log/haproxy
+systemctl stop mysql-default
+systemctl disable mysql-default
+systemctl stop tomcat-share
+systemctl disable tomcat-share
+yum remove -y mysql-server
+rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service
+rm -fr /etc/tomcat-share /var/lib/tomcat-share /usr/share/tomcat-share /var/log/tomcat-share /var/cache/tomcat-share /etc/sysconfig/tomcat-share /usr/lib/systemd/system/tomcat-share.service
+rm -fr /etc/chef/chef-client.json
+rm -fr /etc/chef/nodes/*.json
+chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties
+rm -fr /etc/chef/replaceValues.sh
+rm -fr /etc/chef/run.sh
+systemctl restart tomcat-alfresco

--- a/scripts/run-share-fk.sh
+++ b/scripts/run-share-fk.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+cd /etc/chef; chef-client -z -j chef-client.json
+systemctl stop mysql-default
+systemctl disable mysql-default
+yum remove -y mysql-server
+rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service
+service solr stop
+chkconfig --del solr
+rm -rf /opt/alfresco-search-services /var/solr /etc/init.d/solr /etc/sysconfig/solr /var/log/solr /etc/default/solr.in.sh
+userdel -r solr
+rm -fr /etc/chef/chef-client.json
+rm -fr /etc/chef/nodes/*.json
+chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties
+chmod 700 /usr/share/tomcat/shared/classes/alfresco/web-extension/share-cluster-application-context.xml
+rm -fr /etc/chef/replaceValues.sh
+rm -fr /etc/chef/run.sh

--- a/scripts/run-share.sh
+++ b/scripts/run-share.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+cd /etc/chef; chef-client -z -j chef-client.json
+systemctl stop mysql-default
+systemctl disable mysql-default
+yum remove -y mysql-server
+rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service
+service solr stop
+chkconfig --del solr
+rm -rf /opt/alfresco-search-services /var/solr /etc/init.d/solr /etc/sysconfig/solr /var/log/solr /etc/default/solr.in.sh
+userdel -r solr
+rm -fr /etc/chef/chef-client.json
+rm -fr /etc/chef/nodes/*.json
+chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties
+chmod 700 /usr/share/tomcat/shared/classes/alfresco/web-extension/share-cluster-application-context.xml
+rm -fr /etc/chef/replaceValues.sh
+rm -fr /etc/chef/run.sh
+systemctl restart tomcat-alfresco

--- a/scripts/share-52.json
+++ b/scripts/share-52.json
@@ -1,6 +1,19 @@
 {
     "name": "share",
-    "semaphore" : { "s3_bucket_name" : "@@CONTENTSTORE_S3_BUCKET@@-9282744662728828" },
+    "semaphore" : {
+         "wait_while_service_up":{
+              "force_wait": false
+           },
+          "parallel": true,
+          "service_url" : "http://localhost:8070/alfresco",
+          "s3_bucket_lock" : {
+           "name": "@@CONTENTSTORE_S3_BUCKET@@-928274"
+         },
+         "s3_bucket_done" : {
+          "name": "@@CONTENTSTORE_S3_BUCKET@@",
+          "aws_region": "@@AWS_REGION@@"
+         }
+        },
     "chef_client" : {
       "config" : {
         "yum_lock_timeout" : 120
@@ -10,7 +23,7 @@
       "use_nossl_config" : true
     },
     "alfresco" : {
-        "use_libreoffice_os_repo" : true,
+        "components" : ["haproxy","nginx","tomcat","transform","repo","share","googledocs","aos"],
         "db_ssl_enabled" : true,
         "skip_certificate_creation" : true,
         "rmi_server_hostname" : "localhost",
@@ -18,7 +31,6 @@
         "log.json.enabled" : false,
         "public_protocol" : "http",
         "public_portssl" : "80",
-        "components" : ["repo","share"],
         "ssl_enabled" : false,
         "shared" : "/usr/share/tomcat/shared",
         "generate.share.config.custom" : true,
@@ -33,8 +45,7 @@
           "alfresco.port" : "8070"
         },
         "properties" : {
-            "dir.root" : "/usr/share/tomcat/alf_data",
-            "jodconverter.officeHome" : "/opt/libreoffice4.4",
+            "jodconverter.officeHome" : "/opt/libreoffice5.2/",
             "s3.accessKey" : "@@AWS_ACCESS_KEY@@",
             "s3.secretKey" : "@@AWS_SECRET_KEY@@",
             "db.host" : "@@DB_HOST@@",
@@ -101,5 +112,5 @@
             "type" : "amp"
         }
     },
-    "run_list": ["commons::ec2-tagging", "commons::artifact-deployer", "alfresco::apply-amps", "alfresco::share", "alfresco::haproxy", "alfresco::nginx-conf", "commons::start_instance", "alfresco::redeploy", "commons::wait_instance", "commons::stop_instance"]
+    "run_list": ["commons::ec2-tagging", "commons::artifact-deployer", "alfresco::apply-amps", "alfresco::share", "alfresco::haproxy", "alfresco-webserver::start", "commons::start_instance", "alfresco::redeploy", "commons::wait_instance", "commons::stop_instance"]
 }

--- a/scripts/solr-52.json
+++ b/scripts/solr-52.json
@@ -1,25 +1,35 @@
 {
     "name": "solr",
-    "semaphore" : { "s3_bucket_name" : "@@CONTENTSTORE_S3_BUCKET@@-9282744662728828" },
+    "semaphore" : {
+         "wait_while_service_up":{
+              "force_wait": false
+           },
+          "parallel": true,
+          "service_url" : "http://localhost:8070/alfresco",
+          "s3_bucket_lock" : {
+           "name": "@@CONTENTSTORE_S3_BUCKET@@-928274"
+         },
+         "s3_bucket_done" : {
+          "name": "@@CONTENTSTORE_S3_BUCKET@@",
+          "aws_region": "@@AWS_REGION@@"
+         }
+        },
     "chef_client" : {
       "config" : {
         "yum_lock_timeout" : 120
       }
      },
     "alfresco" : {
-        "use_libreoffice_os_repo" : true,
+        "components" : ["tomcat","transform","repo","solr6"],
         "db_ssl_enabled" : true,
         "skip_certificate_creation" : true,
         "rmi_server_hostname" : "localhost",
         "public_hostname" : "@@FQDN@@",
         "log.json.enabled" : false,
-        "components" : ["repo","solr"],
         "ssl_enabled" : false,
-        "generate.solr.core.config" : true,
         "properties" : {
-            "dir.root" : "/usr/share/tomcat/alf_data",
-            "jodconverter.officeHome" : "/opt/libreoffice4.4",
             "alfresco.cluster.enabled" : false,
+            "jodconverter.officeHome" : "/opt/libreoffice5.2/",
             "s3.accessKey" : "@@AWS_ACCESS_KEY@@",
             "s3.secretKey" : "@@AWS_SECRET_KEY@@",
             "db.host" : "@@DB_HOST@@",
@@ -32,22 +42,17 @@
             "s3service.https-only" : true,
             "s3service.s3-endpoint-https-port" : "443",
             "s3service.s3-endpoint" : "@@AWS_S3ENDPOINT@@",
-            "solr.port" : "8090",
             "alfresco_user_store.adminpassword" : "@@ALFRESCO_PASSWORD@@"
         },
         "repo_tomcat_instance" : {
             "xmx_ratio" : 0.30
-        },
-        "solr_tomcat_instance" : {
-            "xmx_ratio" : 0.50
-        },
-        "workspace-solrproperties" : {
-            "alfresco.corePoolSize" : 4,
-            "alfresco.port" : "8070"
-        },
-        "archive-solrproperties" : {
-            "alfresco.port" : "8070"
         }
+    },
+    "solr6" : {
+      "xmx_ratio" : 0.3,
+      "solrcore-properties" : {
+        "alfresco.host" : "localhost"
+      }
     },
     "tomcat" : {
         "cleaner.minutes.interval" : 1,
@@ -58,7 +63,7 @@
         "aws_region" : "@@AWS_REGION@@"
       },
       "ec2_tags" : {
-        "haproxy_backends" : "solr",
+        "haproxy_backends" : "solr6",
         "jvm_route" : "@@JVM_ROUTE@@",
         "status" : "complete"
       }
@@ -79,5 +84,5 @@
             "type" : "amp"
         }
     },
-    "run_list": ["commons::ec2-tagging", "alfresco::solr-config", "commons::artifact-deployer" ,"alfresco::repo", "alfresco::apply-amps", "commons::start_instance", "alfresco::redeploy", "commons::wait_instance", "commons::stop_instance"]
+    "run_list": ["commons::ec2-tagging", "commons::artifact-deployer" ,"alfresco::repo", "alfresco::apply-amps", "commons::start_instance", "alfresco::redeploy", "commons::wait_instance", "commons::stop_instance"]
 }

--- a/templates/alfresco-content-services-master.template
+++ b/templates/alfresco-content-services-master.template
@@ -549,7 +549,9 @@
                     ]
                 },
                 "Parameters": {
-                    "BastionAMIOS": "Amazon-Linux-HVM",
+                    "BastionAMIOS": {
+                        "Ref": "BastionAMIOS"
+                    },
                     "BastionInstanceType": {
                         "Ref": "BastionInstanceType"
                     },
@@ -598,7 +600,29 @@
             "DependsOn": "BastionStack",
             "Type": "AWS::CloudFormation::Stack",
             "Properties": {
-                "TemplateURL": "https://s3.amazonaws.com/cfn-templates-qs/alfresco-content-services.template",
+                "TemplateURL": {
+                  "Fn::Join": [
+                      "/",
+                      [
+                          {
+                              "Fn::FindInMap": [
+                                  "AWSInfoRegionMap",
+                                  {
+                                      "Ref": "AWS::Region"
+                                  },
+                                  "QuickStartS3URL"
+                              ]
+                          },
+                          {
+                              "Ref": "QSS3BucketName"
+                          },
+                          {
+                              "Ref": "QSS3KeyPrefix"
+                          },
+                          "templates/alfresco-content-services.template"
+                      ]
+                  ]
+                },
                 "Parameters": {
                     "AlfrescoInstanceType": {
                         "Ref": "AlfrescoInstanceType"

--- a/templates/alfresco-content-services-master.template
+++ b/templates/alfresco-content-services-master.template
@@ -1,6 +1,6 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "This Alfresco Content Services 5.2 workload template deploys an Alfresco cluster behind an ELB load balancer in two private subnets. The cluster is configured to use an S3 bucket for storage and a multi-AZ Amazon RDS Aurora instance for the database (MySQL for Frankfurt). **WARNING** This template creates EC2 instances and related resources. You will be billed for the AWS resources used if you create a stack from this template. QS(5025)",
+    "Description": "This master template creates a VPC infrastructure for a multi-AZ, multi-tier deployment of Alfresco Content Services on AWS. It deploys a VPC with bastions and an Alfresco cluster behind an ELB. The cluster is configured to use an S3 bucket for storage and a multi-AZ Amazon RDS MySQL instance for the database. **WARNING** This template creates EC2 instances and related resources. You will be billed for the AWS resources used if you create a stack from this template.",
     "Metadata": {
         "AWS::CloudFormation::Interface": {
             "ParameterGroups": [

--- a/templates/alfresco-content-services-master.template
+++ b/templates/alfresco-content-services-master.template
@@ -1,6 +1,6 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "This master template creates a VPC infrastructure for a multi-AZ, multi-tier deployment of Alfresco One on AWS. It deploys a VPC with bastions and an Alfresco cluster behind an ELB. The cluster is configured to use an S3 bucket for storage and a multi-AZ Amazon RDS MySQL instance for the database. **WARNING** This template creates EC2 instances and related resources. You will be billed for the AWS resources used if you create a stack from this template.",
+    "Description": "This Alfresco Content Services 5.2 workload template deploys an Alfresco cluster behind an ELB load balancer in two private subnets. The cluster is configured to use an S3 bucket for storage and a multi-AZ Amazon RDS Aurora instance for the database (MySQL for Frankfurt). **WARNING** This template creates EC2 instances and related resources. You will be billed for the AWS resources used if you create a stack from this template. QS(5025)",
     "Metadata": {
         "AWS::CloudFormation::Interface": {
             "ParameterGroups": [
@@ -24,6 +24,7 @@
                     },
                     "Parameters": [
                         "KeyPairName",
+                        "BastionAMIOS",
                         "BastionInstanceType",
                         "AlfrescoInstanceType",
                         "IndexInstanceType"
@@ -58,6 +59,7 @@
                     },
                     "Parameters": [
                         "RDSInstanceType",
+                        "RDSAllocatedStorage",
                         "RDSDBName",
                         "RDSUsername",
                         "RDSPassword",
@@ -95,6 +97,9 @@
                 },
                 "AvailabilityZones": {
                     "default": "Availability Zones"
+                },
+                "BastionAMIOS": {
+                    "default": "Bastion AMI Operating System"
                 },
                 "BastionInstanceType": {
                     "default": "Bastion Instance Type"
@@ -140,6 +145,9 @@
                 },
                 "RDSInstanceType": {
                     "default": "RDS Instance Type"
+                },
+                "RDSAllocatedStorage": {
+                    "default": "RDS Allocated Storage"
                 },
                 "RDSPassword": {
                     "default": "RDS Password"
@@ -218,6 +226,17 @@
         "AvailabilityZones": {
             "Description": "List of Availability Zones to use for the subnets in the VPC. Only two Availability Zones are used for this deployment, and the logical order of your selections is preserved.",
             "Type": "List<AWS::EC2::AvailabilityZone::Name>"
+        },
+        "BastionAMIOS": {
+            "AllowedValues": [
+                "Amazon-Linux-HVM",
+                "CentOS-7-HVM",
+                "Ubuntu-Server-14.04-LTS-HVM",
+                "Ubuntu-Server-16.04-LTS-HVM"
+            ],
+            "Default": "Amazon-Linux-HVM",
+            "Description": "The Linux distribution for the AMI to be used for the bastion instances",
+            "Type": "String"
         },
         "BastionInstanceType": {
             "AllowedValues": [
@@ -337,43 +356,37 @@
         },
         "RDSDBName": {
             "Default": "alfresco",
-            "Description": "DB name for the Amazon RDS MySQL database",
+            "Description": "DB name for the Amazon RDS Aurora database (MySQL if Frankfurt)",
             "Type": "String"
         },
         "RDSInstanceType": {
             "AllowedValues": [
-                "db.t2.medium",
-                "db.t2.large",
-                "db.m3.medium",
-                "db.m3.large",
-                "db.m3.xlarge",
-                "db.m3.2xlarge",
-                "db.r3.large",
-                "db.r3.xlarge",
-                "db.r3.2xlarge",
-                "db.r3.4xlarge",
-                "db.r3.8xlarge",
-                "db.t2.micro",
-                "db.t2.small",
-                "db.t2.medium",
-                "db.t2.large",
-                "db.m4.medium",
-                "db.m4.large",
-                "db.m4.xlarge"
+              "db.t2.small",
+              "db.t2.medium",
+              "db.r3.large",
+              "db.r3.xlarge",
+              "db.r3.2xlarge",
+              "db.r3.4xlarge",
+              "db.r3.8xlarge"
             ],
             "ConstraintDescription": "Must contain valid RDS instance type",
             "Default": "db.t2.small",
-            "Description": "EC2 instance type for the Amazon RDS MySQL DB instances",
+            "Description": "EC2 instance type for the Amazon RDS DB instances",
             "Type": "String"
         },
         "RDSPassword": {
-            "Description": "Password for the Amazon RDS MySQL database",
+            "Description": "Password for the Amazon RDS database. Minimum 8 characters.",
             "NoEcho": "True",
             "Type": "String"
         },
         "RDSUsername": {
             "Default": "alfresco",
-            "Description": "User name for the Amazon RDS MySQL database",
+            "Description": "User name for the Amazon RDS database",
+            "Type": "String"
+        },
+        "RDSAllocatedStorage": {
+            "Default": "5",
+            "Description": "Size in GB for the Amazon RDS MySQL database allocated storage (only Frankfurt)",
             "Type": "String"
         },
         "RemoteAccessCIDR": {
@@ -383,7 +396,8 @@
             "Type": "String"
         },
         "S3BucketName": {
-            "Default": "",
+            "AllowedPattern": "^[a-z0-9][a-z0-9-.]*$",
+            "Default": "type-unique-value-here-in-lowercase",
             "Description": "Name of the S3 bucket that will be created for Alfresco to store data. Enter a unique name that does not include uppercase characters.",
             "Type": "String"
         },
@@ -558,7 +572,7 @@
                         "Ref": "QSS3BucketName"
                     },
                     "QSS3KeyPrefix": {
-                        "Fn::Join": [
+                         "Fn::Join": [
                             "/",
                             [
                                 {
@@ -584,29 +598,7 @@
             "DependsOn": "BastionStack",
             "Type": "AWS::CloudFormation::Stack",
             "Properties": {
-                "TemplateURL": {
-                    "Fn::Join": [
-                        "/",
-                        [
-                            {
-                                "Fn::FindInMap": [
-                                    "AWSInfoRegionMap",
-                                    {
-                                        "Ref": "AWS::Region"
-                                    },
-                                    "QuickStartS3URL"
-                                ]
-                            },
-                            {
-                                "Ref": "QSS3BucketName"
-                            },
-                            {
-                                "Ref": "QSS3KeyPrefix"
-                            },
-                            "templates/alfresco-one.template"
-                        ]
-                    ]
-                },
+                "TemplateURL": "https://s3.amazonaws.com/cfn-templates-qs/alfresco-content-services.template",
                 "Parameters": {
                     "AlfrescoInstanceType": {
                         "Ref": "AlfrescoInstanceType"

--- a/templates/alfresco-content-services.template
+++ b/templates/alfresco-content-services.template
@@ -296,7 +296,7 @@
         "QSS3KeyPrefix": {
             "AllowedPattern": "^[0-9a-zA-Z-]+(/[0-9a-zA-Z-]+)*$",
             "ConstraintDescription": "Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/). It cannot start or end with forward slash (/), which is automatically appended.",
-            "Default": "alfresco/one/latest",
+            "Default": "alfresco/content/services/latest",
             "Description": "S3 key prefix for the Quick Start assets. This prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/). It cannot start or end with a forward slash (/), which is automatically appended.",
             "Type": "String"
         },
@@ -332,12 +332,11 @@
         },
         "RDSAllocatedStorage": {
             "Default": "5",
-            "Description": "Size in GB for the Amazon RDS MySQL database allocated storage (only Frankfurt)",
+            "Description": "Size in GiB for the Amazon RDS MySQL database allocated storage (only Frankfurt)",
             "Type": "String"
         },
         "S3BucketName": {
-            "AllowedPattern": "^[a-z0-9][a-z0-9-.]*$",
-            "Default": "type-unique-value-here-in-lowercase",
+            "Default": "",
             "Description": "Name of the S3 bucket that will be created for Alfresco to store data. Enter a unique name that does not include uppercase characters.",
             "Type": "String"
         },
@@ -371,43 +370,43 @@
     "Mappings": {
         "AWSAMIRegionMap": {
             "AMI": {
-                "ALFRESCOONEHVM": "Alfresco Content Services 5.2.0 AMI 0.0.41"
+                "ALFRESCOCS52": "Alfresco Content Services 5.2.0 AMI 0.0.41"
             },
             "ap-northeast-1": {
-                "ALFRESCOONEHVM": "ami-a99bcece"
+                "ALFRESCOCS52": "ami-a99bcece"
             },
             "ap-northeast-2": {
-                "ALFRESCOONEHVM": "ami-f920f097"
+                "ALFRESCOCS52": "ami-f920f097"
             },
             "ap-south-1": {
-                "ALFRESCOONEHVM": "ami-981d6df7"
+                "ALFRESCOCS52": "ami-981d6df7"
             },
             "ap-southeast-1": {
-                "ALFRESCOONEHVM": "ami-9208b9f1"
+                "ALFRESCOCS52": "ami-9208b9f1"
             },
             "ap-southeast-2": {
-                "ALFRESCOONEHVM": "ami-82cecde1"
+                "ALFRESCOCS52": "ami-82cecde1"
             },
             "eu-central-1": {
-                "ALFRESCOONEHVM": "ami-7de53012"
+                "ALFRESCOCS52": "ami-7de53012"
             },
             "eu-west-1": {
-                "ALFRESCOONEHVM": "ami-1d68467b"
+                "ALFRESCOCS52": "ami-1d68467b"
             },
             "sa-east-1": {
-                "ALFRESCOONEHVM": "ami-5587e139"
+                "ALFRESCOCS52": "ami-5587e139"
             },
             "us-east-1": {
-                "ALFRESCOONEHVM": "ami-ac9d43ba"
+                "ALFRESCOCS52": "ami-ac9d43ba"
             },
             "us-east-2": {
-                "ALFRESCOONEHVM": "ami-c4bb9ea1"
+                "ALFRESCOCS52": "ami-c4bb9ea1"
             },
             "us-west-1": {
-                "ALFRESCOONEHVM": "ami-3c97c95c"
+                "ALFRESCOCS52": "ami-3c97c95c"
             },
             "us-west-2": {
-                "ALFRESCOONEHVM": "ami-16f97b76"
+                "ALFRESCOCS52": "ami-16f97b76"
             }
         },
         "AWSInfoRegionMap": {
@@ -1005,7 +1004,29 @@
                     "Install": {
                         "files": {
                             "/etc/chef/chef-client.json": {
-                                "source": "https://s3.amazonaws.com/cfn-templates-qs/scripts/share-52.json",
+                              "source": {
+                                  "Fn::Join": [
+                                      "/",
+                                      [
+                                          {
+                                              "Fn::FindInMap": [
+                                                  "AWSInfoRegionMap",
+                                                  {
+                                                      "Ref": "AWS::Region"
+                                                  },
+                                                  "QuickStartS3URL"
+                                              ]
+                                          },
+                                          {
+                                              "Ref": "QSS3BucketName"
+                                          },
+                                          {
+                                              "Ref": "QSS3KeyPrefix"
+                                          },
+                                          "scripts/share-52.json"
+                                      ]
+                                  ]
+                                },
                                 "mode": "000700",
                                 "owner": "root",
                                 "group": "root"
@@ -1112,29 +1133,28 @@
                                 "group": "root"
                             },
                             "/etc/chef/run.sh": {
-                                "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "#!/bin/bash\n",
-                                            "cd /etc/chef; chef-client -z -j chef-client.json\n",
-                                            "systemctl stop mysql-default\n",
-                                            "systemctl disable mysql-default\n",
-                                            "yum remove -y mysql-server\n",
-                                            "rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service\n",
-                                            "service solr stop\n",
-                                            "chkconfig --del solr\n",
-                                            "rm -rf /opt/alfresco-search-services /var/solr /etc/init.d/solr /etc/sysconfig/solr /var/log/solr /etc/default/solr.in.sh \n",
-                                            "userdel -r solr\n",
-                                            "rm -fr /etc/chef/chef-client.json\n",
-                                            "rm -fr /etc/chef/nodes/*.json\n",
-                                            "chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties\n",
-                                            "chmod 700 /usr/share/tomcat/shared/classes/alfresco/web-extension/share-cluster-application-context.xml\n",
-                                            "rm -fr /etc/chef/replaceValues.sh\n",
-                                            "rm -fr /etc/chef/run.sh\n",
-                                            "systemctl restart tomcat-alfresco\n"
-                                        ]
-                                    ]
+                              "source": {
+                                  "Fn::Join": [
+                                      "/",
+                                      [
+                                          {
+                                              "Fn::FindInMap": [
+                                                  "AWSInfoRegionMap",
+                                                  {
+                                                      "Ref": "AWS::Region"
+                                                  },
+                                                  "QuickStartS3URL"
+                                              ]
+                                          },
+                                          {
+                                              "Ref": "QSS3BucketName"
+                                          },
+                                          {
+                                              "Ref": "QSS3KeyPrefix"
+                                          },
+                                          "scripts/run-share.sh"
+                                      ]
+                                  ]
                                 },
                                 "mode": "000700",
                                 "owner": "root",
@@ -1164,7 +1184,7 @@
                         {
                             "Ref": "AWS::Region"
                         },
-                        "ALFRESCOONEHVM"
+                        "ALFRESCOCS52"
                     ]
                 },
                 "InstanceMonitoring": "true",
@@ -1233,7 +1253,29 @@
                     "Install2": {
                         "files": {
                             "/etc/chef/chef-client.json": {
-                                "source": "https://s3.amazonaws.com/cfn-templates-qs/scripts/share-52.json",
+                              "source": {
+                                  "Fn::Join": [
+                                      "/",
+                                      [
+                                          {
+                                              "Fn::FindInMap": [
+                                                  "AWSInfoRegionMap",
+                                                  {
+                                                      "Ref": "AWS::Region"
+                                                  },
+                                                  "QuickStartS3URL"
+                                              ]
+                                          },
+                                          {
+                                              "Ref": "QSS3BucketName"
+                                          },
+                                          {
+                                              "Ref": "QSS3KeyPrefix"
+                                          },
+                                          "scripts/share-51.json"
+                                      ]
+                                  ]
+                                },
                                 "mode": "000700",
                                 "owner": "root",
                                 "group": "root"
@@ -1340,28 +1382,28 @@
                                 "group": "root"
                             },
                             "/etc/chef/run.sh": {
-                                "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "#!/bin/bash\n",
-                                            "cd /etc/chef; chef-client -z -j chef-client.json\n",
-                                            "systemctl stop mysql-default\n",
-                                            "systemctl disable mysql-default\n",
-                                            "yum remove -y mysql-server\n",
-                                            "rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service\n",
-                                            "service solr stop\n",
-                                            "chkconfig --del solr\n",
-                                            "rm -rf /opt/alfresco-search-services /var/solr /etc/init.d/solr /etc/sysconfig/solr /var/log/solr /etc/default/solr.in.sh \n",
-                                            "userdel -r solr\n",
-                                            "rm -fr /etc/chef/chef-client.json\n",
-                                            "rm -fr /etc/chef/nodes/*.json\n",
-                                            "chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties\n",
-                                            "chmod 700 /usr/share/tomcat/shared/classes/alfresco/web-extension/share-cluster-application-context.xml\n",
-                                            "rm -fr /etc/chef/replaceValues.sh\n",
-                                            "rm -fr /etc/chef/run.sh\n"
-                                        ]
-                                    ]
+                              "source": {
+                                  "Fn::Join": [
+                                      "/",
+                                      [
+                                          {
+                                              "Fn::FindInMap": [
+                                                  "AWSInfoRegionMap",
+                                                  {
+                                                      "Ref": "AWS::Region"
+                                                  },
+                                                  "QuickStartS3URL"
+                                              ]
+                                          },
+                                          {
+                                              "Ref": "QSS3BucketName"
+                                          },
+                                          {
+                                              "Ref": "QSS3KeyPrefix"
+                                          },
+                                          "scripts/run-share-fk.sh"
+                                      ]
+                                  ]
                                 },
                                 "mode": "000700",
                                 "owner": "root",
@@ -1391,7 +1433,7 @@
                         {
                             "Ref": "AWS::Region"
                         },
-                        "ALFRESCOONEHVM"
+                        "ALFRESCOCS52"
                     ]
                 },
                 "InstanceMonitoring": "true",
@@ -1600,7 +1642,29 @@
                     "Install": {
                         "files": {
                             "/etc/chef/chef-client.json": {
-                                "source": "https://s3.amazonaws.com/cfn-templates-qs/scripts/solr-52.json",
+                              "source": {
+                                  "Fn::Join": [
+                                      "/",
+                                      [
+                                          {
+                                              "Fn::FindInMap": [
+                                                  "AWSInfoRegionMap",
+                                                  {
+                                                      "Ref": "AWS::Region"
+                                                  },
+                                                  "QuickStartS3URL"
+                                              ]
+                                          },
+                                          {
+                                              "Ref": "QSS3BucketName"
+                                          },
+                                          {
+                                              "Ref": "QSS3KeyPrefix"
+                                          },
+                                          "scripts/solr-52.json"
+                                      ]
+                                  ]
+                                },
                                 "mode": "000700",
                                 "owner": "root",
                                 "group": "root"
@@ -1707,35 +1771,28 @@
                                 "group": "root"
                             },
                             "/etc/chef/run.sh": {
-                                "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "#!/bin/bash\n",
-                                            "cd /etc/chef; chef-client -z -j chef-client.json\n",
-                                            "systemctl stop nginx\n",
-                                            "systemctl disable nginx\n",
-                                            "yum remove -y nginx\n",
-                                            "systemctl disable haproxy\n",
-                                            "systemctl stop haproxy\n",
-                                            "yum remove -y haproxy\n",
-                                            "rm -fr /etc/haproxy/haproxy.cfg\n",
-                                            "rm -fr /var/log/haproxy\n",
-                                            "systemctl stop mysql-default\n",
-                                            "systemctl disable mysql-default\n",
-                                            "systemctl stop tomcat-share\n",
-                                            "systemctl disable tomcat-share\n",
-                                            "yum remove -y mysql-server\n",
-                                            "rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service\n",
-                                            "rm -fr /etc/tomcat-share /var/lib/tomcat-share /usr/share/tomcat-share /var/log/tomcat-share /var/cache/tomcat-share /etc/sysconfig/tomcat-share /usr/lib/systemd/system/tomcat-share.service\n",
-                                            "rm -fr /etc/chef/chef-client.json\n",
-                                            "rm -fr /etc/chef/nodes/*.json\n",
-                                            "chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties\n",
-                                            "rm -fr /etc/chef/replaceValues.sh\n",
-                                            "rm -fr /etc/chef/run.sh\n",
-                                            "systemctl restart tomcat-alfresco\n"
-                                        ]
-                                    ]
+                              "source": {
+                                  "Fn::Join": [
+                                      "/",
+                                      [
+                                          {
+                                              "Fn::FindInMap": [
+                                                  "AWSInfoRegionMap",
+                                                  {
+                                                      "Ref": "AWS::Region"
+                                                  },
+                                                  "QuickStartS3URL"
+                                              ]
+                                          },
+                                          {
+                                              "Ref": "QSS3BucketName"
+                                          },
+                                          {
+                                              "Ref": "QSS3KeyPrefix"
+                                          },
+                                          "scripts/run-index.sh"
+                                      ]
+                                  ]
                                 },
                                 "mode": "000700",
                                 "owner": "root",
@@ -1765,7 +1822,7 @@
                         {
                             "Ref": "AWS::Region"
                         },
-                        "ALFRESCOONEHVM"
+                        "ALFRESCOCS52"
                     ]
                 },
                 "InstanceMonitoring": "true",
@@ -1834,7 +1891,29 @@
                     "Install2": {
                         "files": {
                             "/etc/chef/chef-client.json": {
-                                "source": "https://s3.amazonaws.com/cfn-templates-qs/scripts/solr-52.json",
+                              "source": {
+                                  "Fn::Join": [
+                                      "/",
+                                      [
+                                          {
+                                              "Fn::FindInMap": [
+                                                  "AWSInfoRegionMap",
+                                                  {
+                                                      "Ref": "AWS::Region"
+                                                  },
+                                                  "QuickStartS3URL"
+                                              ]
+                                          },
+                                          {
+                                              "Ref": "QSS3BucketName"
+                                          },
+                                          {
+                                              "Ref": "QSS3KeyPrefix"
+                                          },
+                                          "scripts/solr-52.json"
+                                      ]
+                                  ]
+                                },
                                 "mode": "000700",
                                 "owner": "root",
                                 "group": "root"
@@ -1941,34 +2020,28 @@
                                 "group": "root"
                             },
                             "/etc/chef/run.sh": {
-                                "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "#!/bin/bash\n",
-                                            "cd /etc/chef; chef-client -z -j chef-client.json\n",
-                                            "systemctl stop nginx\n",
-                                            "systemctl disable nginx\n",
-                                            "yum remove -y nginx\n",
-                                            "systemctl disable haproxy\n",
-                                            "systemctl stop haproxy\n",
-                                            "yum remove -y haproxy\n",
-                                            "rm -fr /etc/haproxy/haproxy.cfg\n",
-                                            "rm -fr /var/log/haproxy\n",
-                                            "systemctl stop mysql-default\n",
-                                            "systemctl disable mysql-default\n",
-                                            "systemctl stop tomcat-share\n",
-                                            "systemctl disable tomcat-share\n",
-                                            "yum remove -y mysql-server\n",
-                                            "rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service\n",
-                                            "rm -fr /etc/tomcat-share /var/lib/tomcat-share /usr/share/tomcat-share /var/log/tomcat-share /var/cache/tomcat-share /etc/sysconfig/tomcat-share /usr/lib/systemd/system/tomcat-share.service\n",
-                                            "rm -fr /etc/chef/chef-client.json\n",
-                                            "rm -fr /etc/chef/nodes/*.json\n",
-                                            "chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties\n",
-                                            "rm -fr /etc/chef/replaceValues.sh\n",
-                                            "rm -fr /etc/chef/run.sh\n"
-                                        ]
-                                    ]
+                              "source": {
+                                  "Fn::Join": [
+                                      "/",
+                                      [
+                                          {
+                                              "Fn::FindInMap": [
+                                                  "AWSInfoRegionMap",
+                                                  {
+                                                      "Ref": "AWS::Region"
+                                                  },
+                                                  "QuickStartS3URL"
+                                              ]
+                                          },
+                                          {
+                                              "Ref": "QSS3BucketName"
+                                          },
+                                          {
+                                              "Ref": "QSS3KeyPrefix"
+                                          },
+                                          "scripts/run-index-fk.sh"
+                                      ]
+                                  ]
                                 },
                                 "mode": "000700",
                                 "owner": "root",
@@ -1998,7 +2071,7 @@
                         {
                             "Ref": "AWS::Region"
                         },
-                        "ALFRESCOONEHVM"
+                        "ALFRESCOCS52"
                     ]
                 },
                 "InstanceMonitoring": "true",

--- a/templates/alfresco-content-services.template
+++ b/templates/alfresco-content-services.template
@@ -1,6 +1,6 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
-    "Description": "This Alfresco One workload template deploys an Alfresco cluster behind an ELB load balancer in two private subnets. The cluster is configured to use an S3 bucket for storage and a multi-AZ Amazon RDS MySQL instance for the database. **WARNING** This template creates EC2 instances and related resources. You will be billed for the AWS resources used if you create a stack from this template. QS(5025)",
+    "Description": "This Alfresco Content Services 5.2 workload template deploys an Alfresco cluster behind an ELB load balancer in two private subnets. The cluster is configured to use an S3 bucket for storage and a multi-AZ Amazon RDS Aurora instance for the database (MySQL for Frankfurt). **WARNING** This template creates EC2 instances and related resources. You will be billed for the AWS resources used if you create a stack from this template. QS(5025)",
     "Metadata": {
         "AWS::CloudFormation::Interface": {
             "ParameterGroups": [
@@ -56,6 +56,7 @@
                     },
                     "Parameters": [
                         "RDSInstanceType",
+                        "RDSAllocatedStorage",
                         "RDSDBName",
                         "RDSUsername",
                         "RDSPassword",
@@ -135,6 +136,9 @@
                 },
                 "RDSInstanceType": {
                     "default": "RDS Instance Type"
+                },
+                "RDSAllocatedStorage": {
+                    "default": "RDS Allocated Storage"
                 },
                 "RDSPassword": {
                     "default": "RDS Password"
@@ -298,47 +302,42 @@
         },
         "RDSDBName": {
             "Default": "alfresco",
-            "Description": "DB name for the Amazon RDS MySQL database",
+            "Description": "DB name for the Amazon RDS Aurora database (MySQL if Frankfurt).",
             "Type": "String"
         },
         "RDSInstanceType": {
             "AllowedValues": [
+                "db.t2.small",
                 "db.t2.medium",
-                "db.t2.large",
-                "db.m3.medium",
-                "db.m3.large",
-                "db.m3.xlarge",
-                "db.m3.2xlarge",
                 "db.r3.large",
                 "db.r3.xlarge",
                 "db.r3.2xlarge",
                 "db.r3.4xlarge",
-                "db.r3.8xlarge",
-                "db.t2.micro",
-                "db.t2.small",
-                "db.t2.medium",
-                "db.t2.large",
-                "db.m4.medium",
-                "db.m4.large",
-                "db.m4.xlarge"
+                "db.r3.8xlarge"
             ],
             "ConstraintDescription": "Must contain valid RDS instance type",
             "Default": "db.t2.small",
-            "Description": "EC2 instance type for the Amazon RDS MySQL DB instances",
+            "Description": "EC2 instance type for the Amazon RDS instances",
             "Type": "String"
         },
         "RDSPassword": {
-            "Description": "Password for the Amazon RDS MySQL database",
+            "Description": "Password for the Amazon RDS database. Minimum 8 characters.",
             "NoEcho": "True",
             "Type": "String"
         },
         "RDSUsername": {
             "Default": "alfresco",
-            "Description": "User name for the Amazon RDS MySQL database",
+            "Description": "User name for the Amazon RDS database",
+            "Type": "String"
+        },
+        "RDSAllocatedStorage": {
+            "Default": "5",
+            "Description": "Size in GB for the Amazon RDS MySQL database allocated storage (only Frankfurt)",
             "Type": "String"
         },
         "S3BucketName": {
-            "Default": "",
+            "AllowedPattern": "^[a-z0-9][a-z0-9-.]*$",
+            "Default": "type-unique-value-here-in-lowercase",
             "Description": "Name of the S3 bucket that will be created for Alfresco to store data. Enter a unique name that does not include uppercase characters.",
             "Type": "String"
         },
@@ -372,43 +371,43 @@
     "Mappings": {
         "AWSAMIRegionMap": {
             "AMI": {
-                "ALFRESCOONEHVM": "Alfresco One 5.1.1.5 CloudFormation AMI 0.0.40 - 1477326469-580bd3b9-d7b4-498e-8c54-15e5c39b4087-ami-dd035fca.3"
+                "ALFRESCOONEHVM": "Alfresco Content Services 5.2.0 AMI 0.0.41"
             },
             "ap-northeast-1": {
-                "ALFRESCOONEHVM": "ami-dfc26fbe"
+                "ALFRESCOONEHVM": "ami-a99bcece"
             },
             "ap-northeast-2": {
-                "ALFRESCOONEHVM": "ami-c526f2ab"
+                "ALFRESCOONEHVM": "ami-f920f097"
             },
             "ap-south-1": {
-                "ALFRESCOONEHVM": "ami-93a5d1fc"
+                "ALFRESCOONEHVM": "ami-981d6df7"
             },
             "ap-southeast-1": {
-                "ALFRESCOONEHVM": "ami-f41ebf97"
+                "ALFRESCOONEHVM": "ami-9208b9f1"
             },
             "ap-southeast-2": {
-                "ALFRESCOONEHVM": "ami-662f1305"
+                "ALFRESCOONEHVM": "ami-82cecde1"
             },
             "eu-central-1": {
-                "ALFRESCOONEHVM": "ami-3e936851"
+                "ALFRESCOONEHVM": "ami-7de53012"
             },
             "eu-west-1": {
-                "ALFRESCOONEHVM": "ami-8292d8f1"
+                "ALFRESCOONEHVM": "ami-1d68467b"
             },
             "sa-east-1": {
-                "ALFRESCOONEHVM": "ami-5c51cd30"
+                "ALFRESCOONEHVM": "ami-5587e139"
             },
             "us-east-1": {
-                "ALFRESCOONEHVM": "ami-568bd141"
+                "ALFRESCOONEHVM": "ami-ac9d43ba"
             },
             "us-east-2": {
-                "ALFRESCOONEHVM": "ami-63257f06"
+                "ALFRESCOONEHVM": "ami-c4bb9ea1"
             },
             "us-west-1": {
-                "ALFRESCOONEHVM": "ami-cf2268af"
+                "ALFRESCOONEHVM": "ami-3c97c95c"
             },
             "us-west-2": {
-                "ALFRESCOONEHVM": "ami-7d34921d"
+                "ALFRESCOONEHVM": "ami-16f97b76"
             }
         },
         "AWSInfoRegionMap": {
@@ -518,7 +517,13 @@
                     ]
                 }
             ]
-        }
+        },
+        "isFrankfurt": {
+            "Fn::Equals" : [ { "Ref":"AWS::Region" }, "eu-central-1" ]
+          },
+        "isNotFrankfurt": {
+            "Fn::Not": [ { "Fn::Equals" : [ { "Ref":"AWS::Region" }, "eu-central-1" ] } ]
+          }
     },
     "Resources": {
         "NotificationTopic": {
@@ -695,7 +700,7 @@
                                                 {
                                                     "Ref": "S3Bucket"
                                                 },
-                                                "-9282744662728828"
+                                                "-928274"
                                             ]
                                         ]
                                     }
@@ -832,6 +837,7 @@
         },
         "RDSDBInstance": {
             "Type": "AWS::RDS::DBInstance",
+            "Condition": "isFrankfurt",
             "Properties": {
                 "MultiAZ": "true",
                 "VPCSecurityGroups": [
@@ -839,7 +845,7 @@
                         "Ref": "RDSSecurityGroup"
                     }
                 ],
-                "AllocatedStorage": "5",
+                "AllocatedStorage": { "Ref": "RDSAllocatedStorage" },
                 "DBInstanceClass": {
                     "Ref": "RDSInstanceType"
                 },
@@ -858,6 +864,54 @@
                 }
             },
             "DeletionPolicy": "Snapshot"
+        },
+        "RDSCluster" : {
+            "Type" : "AWS::RDS::DBCluster",
+            "Condition": "isNotFrankfurt",
+            "Properties" : {
+              "MasterUsername" : { "Ref" : "RDSUsername" },
+              "MasterUserPassword" : { "Ref" : "RDSPassword" },
+              "Engine" : "aurora",
+              "DatabaseName" : {
+                "Ref" : "RDSDBName"
+              },
+              "VpcSecurityGroupIds": [
+                  {
+                      "Ref": "RDSSecurityGroup"
+                  }
+              ],
+              "DBSubnetGroupName" : { "Ref" : "RDSDBSubnetGroup" }
+            }
+        },
+        "RDSDBInstance1" : {
+            "Type" : "AWS::RDS::DBInstance",
+            "Condition": "isNotFrankfurt",
+            "Properties" : {
+              "DBSubnetGroupName" : {
+                "Ref" : "RDSDBSubnetGroup"
+              },
+              "Engine" : "aurora",
+              "DBClusterIdentifier" : {
+                "Ref" : "RDSCluster"
+              },
+              "PubliclyAccessible" : "false",
+              "DBInstanceClass" : { "Ref": "RDSInstanceType" }
+            }
+        },
+        "RDSDBInstance2" : {
+            "Type" : "AWS::RDS::DBInstance",
+            "Condition": "isNotFrankfurt",
+            "Properties" : {
+              "DBSubnetGroupName" : {
+                "Ref" : "RDSDBSubnetGroup"
+              },
+              "Engine" : "aurora",
+              "DBClusterIdentifier" : {
+                "Ref" : "RDSCluster"
+              },
+              "PubliclyAccessible" : "false",
+              "DBInstanceClass" : { "Ref": "RDSInstanceType" }
+            }
         },
         "AlfrescoSecurityGroup": {
             "Type": "AWS::EC2::SecurityGroup",
@@ -908,6 +962,20 @@
                 }
             }
         },
+        "AlfrescoSecurityGroup5802Ingress": {
+            "Type": "AWS::EC2::SecurityGroupIngress",
+            "Properties": {
+                "GroupId": {
+                    "Ref": "AlfrescoSecurityGroup"
+                },
+                "IpProtocol": "tcp",
+                "FromPort": "5802",
+                "ToPort": "5802",
+                "SourceSecurityGroupId": {
+                    "Ref": "AlfrescoSecurityGroup"
+                }
+            }
+        },
         "AlfrescoSecurityGroup8090Ingress": {
             "Type": "AWS::EC2::SecurityGroupIngress",
             "Properties": {
@@ -924,6 +992,8 @@
         },
         "AlfrescoASLaunchConfig": {
             "Type": "AWS::AutoScaling::LaunchConfiguration",
+            "DependsOn": [ "RDSCluster", "RDSDBInstance1", "RDSDBInstance2" ],
+            "Condition": "isNotFrankfurt",
             "Metadata": {
                 "AWS::CloudFormation::Init": {
                     "configSets": {
@@ -935,29 +1005,235 @@
                     "Install": {
                         "files": {
                             "/etc/chef/chef-client.json": {
-                                "source": {
+                                "source": "https://s3.amazonaws.com/cfn-templates-qs/scripts/share-52.json",
+                                "mode": "000700",
+                                "owner": "root",
+                                "group": "root"
+                            },
+                            "/etc/chef/replaceValues.sh": {
+                                "content": {
                                     "Fn::Join": [
-                                        "/",
+                                        "",
                                         [
+                                            "#!/bin/bash\n",
+                                            "sed -i 's/@@STACK_NAME@@/",
+                                            {
+                                                "Ref": "AWS::StackName"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@FQDN@@/",
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "ElasticLoadBalancer",
+                                                    "DNSName"
+                                                ]
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@AWS_ACCESS_KEY@@/",
+                                            {
+                                                "Ref": "CfnKeys"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's#@@AWS_SECRET_KEY@@#",
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "CfnKeys",
+                                                    "SecretAccessKey"
+                                                ]
+                                            },
+                                            "#g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@DB_HOST@@/",
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "RDSCluster",
+                                                    "Endpoint.Address"
+                                                ]
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@DB_NAME@@/",
+                                            {
+                                                "Ref": "RDSDBName"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@DB_USERNAME@@/",
+                                            {
+                                                "Ref": "RDSUsername"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@DB_PASSWORD@@/",
+                                            {
+                                                "Ref": "RDSPassword"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@CONTENTSTORE_S3_BUCKET@@/",
+                                            {
+                                                "Ref": "S3Bucket"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@AWS_REGION@@/",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@AWS_S3ENDPOINT@@/",
                                             {
                                                 "Fn::FindInMap": [
-                                                    "AWSInfoRegionMap",
+                                                    "S3EndPoints",
                                                     {
                                                         "Ref": "AWS::Region"
                                                     },
-                                                    "QuickStartS3URL"
+                                                    "endpoint"
                                                 ]
                                             },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "ALFPASS=$(printf %s ",
                                             {
-                                                "Ref": "QSS3BucketName"
+                                                "Ref": "AlfrescoPassword"
                                             },
+                                            " | iconv -t utf16le | openssl md4| awk '{ print $2}')\n",
+                                            "sed -i \"s/@@ALFRESCO_PASSWORD@@/$ALFPASS/g\" /etc/chef/chef-client.json\n",
+                                            "export INSTANCEIDX=$(curl http://169.254.169.254/latest/meta-data/instance-id)\n",
+                                            "sed -i \"s/@@JVM_ROUTE@@/share-$INSTANCEIDX/g\" /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@AWS_SG_NAME@@/AlfrescoSecurityGroup/g' /etc/chef/chef-client.json\n",
+                                            "export LOCALIP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)\n",
+                                            "export LOCALNAME=$(curl http://169.254.169.254/latest/meta-data/local-hostname)\n",
+                                            "export LOCALSHORTNAME=$(curl http://169.254.169.254/latest/meta-data/hostname|awk -F. '{print $1}')\n",
+                                            "echo \"$LOCALIP $LOCALSHORTNAME $LOCALNAME\" >> /etc/hosts\n",
+                                            "curl -L ",
                                             {
-                                                "Ref": "QSS3KeyPrefix"
+                                                "Ref": "AlfrescoTrialLicense"
                                             },
-                                            "scripts/share-51.json"
+                                            " -o /usr/share/tomcat/shared/classes/alfresco/extension/license/license.lic\n"
                                         ]
                                     ]
                                 },
+                                "mode": "000700",
+                                "owner": "root",
+                                "group": "root"
+                            },
+                            "/etc/chef/run.sh": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "#!/bin/bash\n",
+                                            "cd /etc/chef; chef-client -z -j chef-client.json\n",
+                                            "systemctl stop mysql-default\n",
+                                            "systemctl disable mysql-default\n",
+                                            "yum remove -y mysql-server\n",
+                                            "rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service\n",
+                                            "service solr stop\n",
+                                            "chkconfig --del solr\n",
+                                            "rm -rf /opt/alfresco-search-services /var/solr /etc/init.d/solr /etc/sysconfig/solr /var/log/solr /etc/default/solr.in.sh \n",
+                                            "userdel -r solr\n",
+                                            "rm -fr /etc/chef/chef-client.json\n",
+                                            "rm -fr /etc/chef/nodes/*.json\n",
+                                            "chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties\n",
+                                            "chmod 700 /usr/share/tomcat/shared/classes/alfresco/web-extension/share-cluster-application-context.xml\n",
+                                            "rm -fr /etc/chef/replaceValues.sh\n",
+                                            "rm -fr /etc/chef/run.sh\n",
+                                            "systemctl restart tomcat-alfresco\n"
+                                        ]
+                                    ]
+                                },
+                                "mode": "000700",
+                                "owner": "root",
+                                "group": "root"
+                            }
+                        }
+                    },
+                    "Configure": {
+                        "commands": {
+                            "01_ReplaceValues": {
+                                "command": "/etc/chef/replaceValues.sh"
+                            },
+                            "02_RunChef": {
+                                "command": "/etc/chef/run.sh"
+                            }
+                        }
+                    }
+                }
+            },
+            "Properties": {
+                "KeyName": {
+                    "Ref": "KeyPairName"
+                },
+                "ImageId": {
+                    "Fn::FindInMap": [
+                        "AWSAMIRegionMap",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        "ALFRESCOONEHVM"
+                    ]
+                },
+                "InstanceMonitoring": "true",
+                "IamInstanceProfile": {
+                    "Ref": "SetupRoleProfile"
+                },
+                "InstanceType": {
+                    "Ref": "AlfrescoInstanceType"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "AlfrescoSecurityGroup"
+                    }
+                ],
+                "UserData": {
+                    "Fn::Base64": {
+                        "Fn::Join": [
+                            "",
+                            [
+                                "#!/bin/bash\n",
+                                "systemctl stop chef-boot.service\n",
+                                "systemctl disable chef-boot.service\n",
+                                "/usr/bin/easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz || sleep 10\n",
+                                "/usr/bin/cfn-init",
+                                "    --stack ",
+                                {
+                                    "Ref": "AWS::StackName"
+                                },
+                                "    --resource AlfrescoASLaunchConfig",
+                                "    --configsets InstallAndRun",
+                                "    --region     ",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                "\n",
+                                "# Signal the status from cfn-init\n",
+                                "/usr/bin/cfn-signal -e $? ",
+                                " --stack ",
+                                {
+                                    "Ref": "AWS::StackName"
+                                },
+                                " --resource AlfrescoAutoScalingGroup",
+                                " --region ",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                "\n"
+                            ]
+                        ]
+                    }
+                }
+            }
+        },
+        "AlfrescoASLaunchConfigFrankfurt": {
+            "Type": "AWS::AutoScaling::LaunchConfiguration",
+            "DependsOn": "RDSDBInstance",
+            "Condition": "isFrankfurt",
+            "Metadata": {
+                "AWS::CloudFormation::Init": {
+                    "configSets": {
+                        "Install2AndRun": [
+                            "Install2",
+                            "Configure"
+                        ]
+                    },
+                    "Install2": {
+                        "files": {
+                            "/etc/chef/chef-client.json": {
+                                "source": "https://s3.amazonaws.com/cfn-templates-qs/scripts/share-52.json",
                                 "mode": "000700",
                                 "owner": "root",
                                 "group": "root"
@@ -1069,24 +1345,15 @@
                                         "",
                                         [
                                             "#!/bin/bash\n",
+                                            "cd /etc/chef; chef-client -z -j chef-client.json\n",
                                             "systemctl stop mysql-default\n",
                                             "systemctl disable mysql-default\n",
-                                            "systemctl stop tomcat-solr\n",
-                                            "systemctl disable tomcat-solr\n",
                                             "yum remove -y mysql-server\n",
                                             "rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service\n",
-                                            "rm -fr /etc/tomcat-solr /var/lib/tomcat-solr /usr/share/tomcat-solr /var/log/tomcat-solr /var/cache/tomcat-solr /usr/share/tomcat/alf_data/solrhome /usr/share/tomcat/alf_data/solrContentStore /usr/share/tomcat/alf_data/solr4Backup /usr/share/tomcat/alf_data/newAlfrescoModels /etc/sysconfig/tomcat-solr /etc/cron.d/solr-cleaner.cron /usr/lib/systemd/system/tomcat-solr.service\n",
-                                            "cd /etc/chef; chef-client -z -j chef-client.json\n",
-                                            "curl 'http://localhost/alfresco/s/enterprise/admin?t=%2Fenterprise%2Fadmin%2Fadmin-transformations' -u admin:",
-                                            {
-                                                "Ref": "AlfrescoPassword"
-                                            },
-                                            " -H 'Content-Type: multipart/form-data; boundary=123456789' --data-binary $'--123456789\\r\\nContent-Disposition: form-data; name=\"Alfresco:Type=Configuration,Category=OOoJodconverter,id1=default|jodconverter.enabled\"\\r\\n\\r\\nfalse\\r\\n--123456789'\n",
-                                            "curl 'http://localhost/alfresco/s/enterprise/admin?t=%2Fenterprise%2Fadmin%2Fadmin-transformations' -u admin:",
-                                            {
-                                                "Ref": "AlfrescoPassword"
-                                            },
-                                            " -H 'Content-Type: multipart/form-data; boundary=123456789' --data-binary $'--123456789\\r\\nContent-Disposition: form-data; name=\"Alfresco:Type=Configuration,Category=OOoJodconverter,id1=default|jodconverter.enabled\"\\r\\n\\r\\ntrue\\r\\n--123456789'\n",
+                                            "service solr stop\n",
+                                            "chkconfig --del solr\n",
+                                            "rm -rf /opt/alfresco-search-services /var/solr /etc/init.d/solr /etc/sysconfig/solr /var/log/solr /etc/default/solr.in.sh \n",
+                                            "userdel -r solr\n",
                                             "rm -fr /etc/chef/chef-client.json\n",
                                             "rm -fr /etc/chef/nodes/*.json\n",
                                             "chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties\n",
@@ -1145,14 +1412,16 @@
                             "",
                             [
                                 "#!/bin/bash\n",
+                                "systemctl stop chef-boot.service\n",
+                                "systemctl disable chef-boot.service\n",
                                 "/usr/bin/easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz || sleep 10\n",
                                 "/usr/bin/cfn-init",
                                 "    --stack ",
                                 {
                                     "Ref": "AWS::StackName"
                                 },
-                                "    --resource AlfrescoASLaunchConfig",
-                                "    --configsets InstallAndRun",
+                                "    --resource AlfrescoASLaunchConfigFrankfurt",
+                                "    --configsets Install2AndRun",
                                 "    --region     ",
                                 {
                                     "Ref": "AWS::Region"
@@ -1267,9 +1536,15 @@
                 },
                 "HealthCheckGracePeriod": "600",
                 "HealthCheckType": "EC2",
-                "LaunchConfigurationName": {
-                    "Ref": "AlfrescoASLaunchConfig"
-                },
+                "LaunchConfigurationName":{
+                    "Fn::If" : [
+                      "isNotFrankfurt",
+                      {
+                         "Ref": "AlfrescoASLaunchConfig"
+                     },{
+                        "Ref": "AlfrescoASLaunchConfigFrankfurt"
+                    }
+                    ]},
                 "LoadBalancerNames": [
                     {
                         "Ref": "ElasticLoadBalancer"
@@ -1312,6 +1587,8 @@
         },
         "IndexASLaunchConfig": {
             "Type": "AWS::AutoScaling::LaunchConfiguration",
+            "DependsOn": "AlfrescoASLaunchConfig",
+            "Condition": "isNotFrankfurt",
             "Metadata": {
                 "AWS::CloudFormation::Init": {
                     "configSets": {
@@ -1323,29 +1600,241 @@
                     "Install": {
                         "files": {
                             "/etc/chef/chef-client.json": {
-                                "source": {
+                                "source": "https://s3.amazonaws.com/cfn-templates-qs/scripts/solr-52.json",
+                                "mode": "000700",
+                                "owner": "root",
+                                "group": "root"
+                            },
+                            "/etc/chef/replaceValues.sh": {
+                                "content": {
                                     "Fn::Join": [
-                                        "/",
+                                        "",
                                         [
+                                            "#!/bin/bash\n",
+                                            "sed -i 's/@@STACK_NAME@@/",
+                                            {
+                                                "Ref": "AWS::StackName"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@FQDN@@/",
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "ElasticLoadBalancer",
+                                                    "DNSName"
+                                                ]
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@AWS_ACCESS_KEY@@/",
+                                            {
+                                                "Ref": "CfnKeys"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's#@@AWS_SECRET_KEY@@#",
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "CfnKeys",
+                                                    "SecretAccessKey"
+                                                ]
+                                            },
+                                            "#g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@DB_HOST@@/",
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "RDSCluster",
+                                                    "Endpoint.Address"
+                                                ]
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@DB_NAME@@/",
+                                            {
+                                                "Ref": "RDSDBName"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@DB_USERNAME@@/",
+                                            {
+                                                "Ref": "RDSUsername"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@DB_PASSWORD@@/",
+                                            {
+                                                "Ref": "RDSPassword"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@CONTENTSTORE_S3_BUCKET@@/",
+                                            {
+                                                "Ref": "S3Bucket"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@AWS_REGION@@/",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@AWS_S3ENDPOINT@@/",
                                             {
                                                 "Fn::FindInMap": [
-                                                    "AWSInfoRegionMap",
+                                                    "S3EndPoints",
                                                     {
                                                         "Ref": "AWS::Region"
                                                     },
-                                                    "QuickStartS3URL"
+                                                    "endpoint"
                                                 ]
                                             },
+                                            "/g' /etc/chef/chef-client.json\n",
+                                            "ALFPASS=$(printf %s ",
                                             {
-                                                "Ref": "QSS3BucketName"
+                                                "Ref": "AlfrescoPassword"
                                             },
+                                            " | iconv -t utf16le | openssl md4| awk '{ print $2}')\n",
+                                            "sed -i \"s/@@ALFRESCO_PASSWORD@@/$ALFPASS/g\" /etc/chef/chef-client.json\n",
+                                            "export INSTANCEIDX=$(curl http://169.254.169.254/latest/meta-data/instance-id)\n",
+                                            "sed -i \"s/@@JVM_ROUTE@@/solr-$INSTANCEIDX/g\" /etc/chef/chef-client.json\n",
+                                            "sed -i 's/@@AWS_SG_NAME@@/AlfrescoSecurityGroup/g' /etc/chef/chef-client.json\n",
+                                            "export LOCALIP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4) \n",
+                                            "export LOCALNAME=$(curl http://169.254.169.254/latest/meta-data/local-hostname)\n ",
+                                            "export LOCALSHORTNAME=$(curl http://169.254.169.254/latest/meta-data/hostname|awk -F. '{print $1}')\n",
+                                            "echo \"$LOCALIP $LOCALSHORTNAME $LOCALNAME\" >> /etc/hosts\n",
+                                            "curl -L ",
                                             {
-                                                "Ref": "QSS3KeyPrefix"
+                                                "Ref": "AlfrescoTrialLicense"
                                             },
-                                            "scripts/solr-51.json"
+                                            " -o /usr/share/tomcat/shared/classes/alfresco/extension/license/license.lic\n"
                                         ]
                                     ]
                                 },
+                                "mode": "000700",
+                                "owner": "root",
+                                "group": "root"
+                            },
+                            "/etc/chef/run.sh": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "#!/bin/bash\n",
+                                            "cd /etc/chef; chef-client -z -j chef-client.json\n",
+                                            "systemctl stop nginx\n",
+                                            "systemctl disable nginx\n",
+                                            "yum remove -y nginx\n",
+                                            "systemctl disable haproxy\n",
+                                            "systemctl stop haproxy\n",
+                                            "yum remove -y haproxy\n",
+                                            "rm -fr /etc/haproxy/haproxy.cfg\n",
+                                            "rm -fr /var/log/haproxy\n",
+                                            "systemctl stop mysql-default\n",
+                                            "systemctl disable mysql-default\n",
+                                            "systemctl stop tomcat-share\n",
+                                            "systemctl disable tomcat-share\n",
+                                            "yum remove -y mysql-server\n",
+                                            "rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service\n",
+                                            "rm -fr /etc/tomcat-share /var/lib/tomcat-share /usr/share/tomcat-share /var/log/tomcat-share /var/cache/tomcat-share /etc/sysconfig/tomcat-share /usr/lib/systemd/system/tomcat-share.service\n",
+                                            "rm -fr /etc/chef/chef-client.json\n",
+                                            "rm -fr /etc/chef/nodes/*.json\n",
+                                            "chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties\n",
+                                            "rm -fr /etc/chef/replaceValues.sh\n",
+                                            "rm -fr /etc/chef/run.sh\n",
+                                            "systemctl restart tomcat-alfresco\n"
+                                        ]
+                                    ]
+                                },
+                                "mode": "000700",
+                                "owner": "root",
+                                "group": "root"
+                            }
+                        }
+                    },
+                    "Configure": {
+                        "commands": {
+                            "01_ReplaceValues": {
+                                "command": "/etc/chef/replaceValues.sh"
+                            },
+                            "02_RunChef": {
+                                "command": "/etc/chef/run.sh"
+                            }
+                        }
+                    }
+                }
+            },
+            "Properties": {
+                "KeyName": {
+                    "Ref": "KeyPairName"
+                },
+                "ImageId": {
+                    "Fn::FindInMap": [
+                        "AWSAMIRegionMap",
+                        {
+                            "Ref": "AWS::Region"
+                        },
+                        "ALFRESCOONEHVM"
+                    ]
+                },
+                "InstanceMonitoring": "true",
+                "IamInstanceProfile": {
+                    "Ref": "SetupRoleProfile"
+                },
+                "InstanceType": {
+                    "Ref": "IndexInstanceType"
+                },
+                "SecurityGroups": [
+                    {
+                        "Ref": "AlfrescoSecurityGroup"
+                    }
+                ],
+                "UserData": {
+                    "Fn::Base64": {
+                        "Fn::Join": [
+                            "",
+                            [
+                                "#!/bin/bash\n",
+                                "systemctl stop chef-boot.service\n",
+                                "systemctl disable chef-boot.service\n",
+                                "/usr/bin/easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz || sleep 10\n",
+                                "/usr/bin/cfn-init",
+                                "    --stack ",
+                                {
+                                    "Ref": "AWS::StackName"
+                                },
+                                "    --resource IndexASLaunchConfig",
+                                "    --configsets InstallAndRun ",
+                                "    --region     ",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                "\n",
+                                "# Signal the status from cfn-init\n",
+                                "/usr/bin/cfn-signal -e $? ",
+                                " --stack ",
+                                {
+                                    "Ref": "AWS::StackName"
+                                },
+                                " --resource IndexAutoScalingGroup",
+                                " --region ",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                "\n"
+                            ]
+                        ]
+                    }
+                }
+            }
+        },
+        "IndexASLaunchConfigFrankfurt": {
+            "Type": "AWS::AutoScaling::LaunchConfiguration",
+            "DependsOn" : "AlfrescoASLaunchConfigFrankfurt",
+            "Condition": "isFrankfurt",
+            "Metadata": {
+                "AWS::CloudFormation::Init": {
+                    "configSets": {
+                        "Install2AndRun": [
+                            "Install2",
+                            "Configure"
+                        ]
+                    },
+                    "Install2": {
+                        "files": {
+                            "/etc/chef/chef-client.json": {
+                                "source": "https://s3.amazonaws.com/cfn-templates-qs/scripts/solr-52.json",
                                 "mode": "000700",
                                 "owner": "root",
                                 "group": "root"
@@ -1457,6 +1946,7 @@
                                         "",
                                         [
                                             "#!/bin/bash\n",
+                                            "cd /etc/chef; chef-client -z -j chef-client.json\n",
                                             "systemctl stop nginx\n",
                                             "systemctl disable nginx\n",
                                             "yum remove -y nginx\n",
@@ -1467,22 +1957,11 @@
                                             "rm -fr /var/log/haproxy\n",
                                             "systemctl stop mysql-default\n",
                                             "systemctl disable mysql-default\n",
-                                            "systemctl stop tomcat-solr\n",
-                                            "systemctl disable tomcat-solr\n",
+                                            "systemctl stop tomcat-share\n",
+                                            "systemctl disable tomcat-share\n",
                                             "yum remove -y mysql-server\n",
                                             "rm -fr /etc/mysql-default* /var/lib/mysql* /var/log/mysql-default* /usr/lib/systemd/system/mysql-default.service\n",
                                             "rm -fr /etc/tomcat-share /var/lib/tomcat-share /usr/share/tomcat-share /var/log/tomcat-share /var/cache/tomcat-share /etc/sysconfig/tomcat-share /usr/lib/systemd/system/tomcat-share.service\n",
-                                            "cd /etc/chef; chef-client -z -j chef-client.json\n",
-                                            "curl 'http://localhost/alfresco/s/enterprise/admin?t=%2Fenterprise%2Fadmin%2Fadmin-transformations' -u admin:",
-                                            {
-                                                "Ref": "AlfrescoPassword"
-                                            },
-                                            " -H 'Content-Type: multipart/form-data; boundary=123456789' --data-binary $'--123456789\\r\\nContent-Disposition: form-data; name=\"Alfresco:Type=Configuration,Category=OOoJodconverter,id1=default|jodconverter.enabled\"\\r\\n\\r\\nfalse\\r\\n--123456789'\n",
-                                            "curl 'http://localhost/alfresco/s/enterprise/admin?t=%2Fenterprise%2Fadmin%2Fadmin-transformations' -u admin:",
-                                            {
-                                                "Ref": "AlfrescoPassword"
-                                            },
-                                            " -H 'Content-Type: multipart/form-data; boundary=123456789' --data-binary $'--123456789\\r\\nContent-Disposition: form-data; name=\"Alfresco:Type=Configuration,Category=OOoJodconverter,id1=default|jodconverter.enabled\"\\r\\n\\r\\ntrue\\r\\n--123456789'\n",
                                             "rm -fr /etc/chef/chef-client.json\n",
                                             "rm -fr /etc/chef/nodes/*.json\n",
                                             "chmod 700 /usr/share/tomcat/shared/classes/alfresco-global.properties\n",
@@ -1540,14 +2019,16 @@
                             "",
                             [
                                 "#!/bin/bash\n",
+                                "systemctl stop chef-boot.service\n",
+                                "systemctl disable chef-boot.service\n",
                                 "/usr/bin/easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz || sleep 10\n",
                                 "/usr/bin/cfn-init",
                                 "    --stack ",
                                 {
                                     "Ref": "AWS::StackName"
                                 },
-                                "    --resource IndexASLaunchConfig",
-                                "    --configsets InstallAndRun ",
+                                "    --resource IndexASLaunchConfigFrankfurt",
+                                "    --configsets Install2AndRun ",
                                 "    --region     ",
                                 {
                                     "Ref": "AWS::Region"
@@ -1662,9 +2143,15 @@
                 },
                 "HealthCheckGracePeriod": "300",
                 "HealthCheckType": "EC2",
-                "LaunchConfigurationName": {
-                    "Ref": "IndexASLaunchConfig"
-                },
+                "LaunchConfigurationName":{
+                    "Fn::If" : [
+                      "isNotFrankfurt",
+                      {
+                         "Ref": "IndexASLaunchConfig"
+                     },{
+                        "Ref": "IndexASLaunchConfigFrankfurt"
+                    }
+                    ]},
                 "MaxSize": {
                     "Ref": "IndexNodesMaxSize"
                 },


### PR DESCRIPTION
Changes:
-S3 bucket name allowed pattern
-NEW AMIs for Alfresco Content Services 5.2
-Added Aurora support if region is not Frankfurt (uses mysql instead)
-Added RDS SllocatedSize as parameter for MySQL.
-Adapted for the new Bastion Stack changes.